### PR TITLE
include where clause checking if a field is empty

### DIFF
--- a/source/content-fetching.md
+++ b/source/content-fetching.md
@@ -78,6 +78,9 @@ select based on 'smaller than' or 'does not equal'
 {# get all pages not created by user '1' #}
 {% setcontent mypages = 'pages' where { ownerid: '!1' } %}
 
+{# get all products where price is not empty #}
+{% setcontent myproducts = 'products' where { price: '!' } %}
+
 {# get all events with eventdate before '2012-10-15' #}
 {% setcontent myevents = 'events' where { eventdate: '<2012-10-15' } %}
 


### PR DESCRIPTION
This issue came up on the irc today - 
nmarques attempted to use {% setcontent members = 'staff' where {position: "!''"} %} to return records where staff was not empty, but found it didn't work. Instead, nmarques figured out that '!' worked: {% setcontent members = 'staff' where {position: '!'} %} 

Since this seems to me to be an unexpected behavior, I figured it should be documented. (Alternatively if it's a bug, then an issue might be opened?)